### PR TITLE
Fixed bug with adding grouping substitutions

### DIFF
--- a/app/evaluation.py
+++ b/app/evaluation.py
@@ -80,9 +80,7 @@ def evaluation_function(response, answer, params) -> dict:
 #            if answer == response:
 #                return {"is_correct": True, "level": params["comparison"]}
 
-    if isinstance(list_of_substitutions_strings,str):
-        list_of_substitutions_strings = [list_of_substitutions_strings]
-    elif not (isinstance(list_of_substitutions_strings,list) and all(isinstance(element,str) for element in list_of_substitutions_strings)):
+    if not (isinstance(list_of_substitutions_strings,list) and all(isinstance(element,str) for element in list_of_substitutions_strings)):
         raise Exception("List of substitutions not written correctly.")
 
     for subs_strings in list_of_substitutions_strings:
@@ -97,7 +95,7 @@ def evaluation_function(response, answer, params) -> dict:
             except (SyntaxError, TypeError) as e:
                 raise Exception("List of substitutions not written correctly.")
             index = subs_strings.find('(',index_match+1)
-            if index > -1 and subs_strings.find('|',index_match+1,index-1) > -1:
+            if index > -1 and subs_strings.find('|',index_match,index) > -1:
                 # Substitutions are sorted so that the longest possible part of the original string will be substituted in each step
                 sub_substitutions.sort(key=lambda x: -len(x[0]))
                 substitutions.append(sub_substitutions)

--- a/app/evaluation_tests.py
+++ b/app/evaluation_tests.py
@@ -93,6 +93,25 @@ class TestEvaluationFunction(unittest.TestCase):
 
         self.assertEqual(response.get("is_correct"), True)
 
+    def test_compare_quantities_with_substitutions_short_form(self):
+        derived_units = "('W','(J/s)')|('J','(N*m)') ('Pa','(N/(m**2))')|('N','(m*(k*g)/(s**2))')"
+        prefixes = "('M','10**6') ('k','10**3') ('h','10**2') ('da','10**1') ('d','10**(-1)') ('c','10**(-2)') ('mu','10**(-6)')"
+        milli_fix = "('mm','10**(-3)*m') ('mg','10**(-3)*g') ('ms','10**(-3)*s')"
+        substitutions = derived_units+"|"+milli_fix+"|"+prefixes
+        params = {"substitutions": substitutions}
+        answer = "1.23*W"
+        is_correct = True
+        response = "123*c*W"
+        is_correct = is_correct and evaluation_function(response, answer, params).get("is_correct")
+        response = "0.00123*k*W"
+        result = is_correct and evaluation_function(response, answer, params).get("is_correct")
+        response = "1.23*J/s"
+        result = is_correct and evaluation_function(response, answer, params).get("is_correct")
+        response = "1.23*k*g*N"
+        result = is_correct and evaluation_function(response, answer, params).get("is_correct")
+        self.assertEqual(is_correct, True)
+
+
     def test_compare_dimensions_with_defaults(self):
         body = {"response": "(d/t)**2*((1/3.6)**2)+v**2", 
                 "answer": "2*v**2", 


### PR DESCRIPTION
While adding an example for defining your own notation via substitutions it was discovered that the parsing sometimes missed the '|' symbol when creating groups of substitutions.