### PR TITLE
Fixed bug with input symbols and implicit multiplication

### DIFF
--- a/app/evaluation.py
+++ b/app/evaluation.py
@@ -13,7 +13,7 @@ parse_error_warning = lambda x: f"`{x}` could not be parsed as a valid mathemati
 
 def evaluation_function(response, answer, params) -> dict:
     """
-    Funtion that provides some basic dimensional analysis functionality.
+    Function that provides some basic dimensional analysis functionality.
     """
     feedback = {}
     default_rtol = 1e-12

--- a/app/expression_utilities.py
+++ b/app/expression_utilities.py
@@ -130,8 +130,14 @@ def create_sympy_parsing_params(params, unsplittable_symbols=tuple()):
         parsing_params: A dictionary that contains necessary info for the
                         parse_expression function.
     '''
+
     if "input_symbols" in params.keys():
-        unsplittable_symbols += tuple(x[0] for x in params["input_symbols"])
+        #unsplittable_symbols += tuple(x[0] for x in params["input_symbols"])
+        to_keep = []
+        for symbol in [x[0] for x in params["input_symbols"]]:
+            if len(symbol) > 1:
+                to_keep.append(symbol)
+        unsplittable_symbols += tuple(to_keep)
 
     if params.get("specialFunctions", False) == True:
         from sympy import beta, gamma, zeta


### PR DESCRIPTION
Single-character input symbols together with implicit multiplication could cause sympy to split function names